### PR TITLE
chore: bump patch versions for plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "firstloop-claude-code-plugins",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Bundled plugins for Claude Code from Firstloop",
   "owner": {
     "name": "Firstloop",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude Code Plugin for Firstloop monorepo template",
   "repository": "https://github.com/firstloophq/claude-code-plugins",
   "license": "MIT"

--- a/plugins/monotemplate/.claude-plugin/plugin.json
+++ b/plugins/monotemplate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monotemplate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core Claude Code plugins for Firstloop projects",
   "repository": "https://github.com/firstloophq/claude-code-plugins",
   "license": "MIT"


### PR DESCRIPTION
## Summary

- Bumped marketplace.json: 1.0.0 → 1.0.1
- Bumped core plugin: 0.1.0 → 0.1.1
- Bumped monotemplate plugin: 0.1.0 → 0.1.1

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)