### PR TITLE
chore: bump all plugin versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "firstloop-claude-code-plugins",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Bundled plugins for Claude Code from Firstloop",
   "owner": {
     "name": "Firstloop",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Claude Code Plugin for Firstloop monorepo template",
   "repository": "https://github.com/firstloophq/claude-code-plugins",
   "license": "MIT"

--- a/plugins/monotemplate/.claude-plugin/plugin.json
+++ b/plugins/monotemplate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monotemplate",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Core Claude Code plugins for Firstloop projects",
   "repository": "https://github.com/firstloophq/claude-code-plugins",
   "license": "MIT"


### PR DESCRIPTION
Bump all plugin versions (patch):

- marketplace: 1.0.1 → 1.0.2
- core plugin: 0.3.0 → 0.3.1
- monotemplate plugin: 0.2.0 → 0.2.1

Closes #29

Generated with [Claude Code](https://claude.ai/code)